### PR TITLE
Add build.bat to build and run API

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,5 @@
+msbuild .\TodoApi.sln
+pushd
+cd .\TodoApi.Web
+dotnet run
+popd


### PR DESCRIPTION
Use MSBuild to build the solution and `dotnet run` to start the webserver at localhost:5000.

This looks good to me. Great work @haacked! You're really my favorite and I wish you success in your open source endeavors!