### PR TITLE
Remove the private keyword

### DIFF
--- a/TodoApi.Web/Controllers/TodoController.cs
+++ b/TodoApi.Web/Controllers/TodoController.cs
@@ -9,7 +9,7 @@ namespace TodoApi.Web.Controllers
     [Route("api/[controller]")]
     public class TodoController : Controller
     {
-        private readonly ITodoRepository _todoRepository;
+        readonly ITodoRepository _todoRepository;
 
         public TodoController(ITodoRepository todoRepository)
         {


### PR DESCRIPTION
Members are private by default. I know it's private. You know it's private. So the private keyword here is just noise. So I removed it.